### PR TITLE
Various minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ D3DADAPTER9_LOCATION="/usr/lib/x86_64-linux-gnu/d3d/d3dadapter9.so"
 D3DADAPTER9_WITHDRI2=1
 
 XNINE=Xnine.o dri3.o
-ifneq ($D3DADAPTER9_WITHDRI2, 0)
-XNINE_LINK=-ldl -lEGL -lGL -lX11 -lXext -lxcb -lxcb-present -lxcb-dri3 -lxcb-xfixes -lX11-xcb
-else
 XNINE_LINK=-ldl -lX11 -lXext -lxcb -lxcb-present -lxcb-dri3 -lxcb-xfixes -lX11-xcb
+
+ifneq ($(D3DADAPTER9_WITHDRI2), 0)
+ XNINE_LINK+=-lEGL -lGL
 endif
 
 SDLNINE=SDL_nine.o dri3.o

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,6 @@ dri3.o: dri3.c
 	gcc -c -g dri3.c -o dri3.o -I include/D3D9 -DD3DADAPTER9_WITHDRI2=$(D3DADAPTER9_WITHDRI2)
 
 clean:
-	rm $(XNINE) $(SDLNINE)
-	rm $(EXEC)
+	rm -f $(XNINE) $(SDLNINE)
+	rm -f $(EXEC)
 

--- a/Xnine.c
+++ b/Xnine.c
@@ -1098,7 +1098,9 @@ BOOL Xnine_init(int screen_num, struct Xnine_private **priv)
     res->screen_width = DisplayWidth(dpy, scrn_num);
     res->screen_height = DisplayHeight(dpy, scrn_num);
     res->d3d9_drm = d3d9_drm;
+#if D3DADAPTER9_WITHDRI2
     res->is_dri2_fallback = is_dri2_fallback;
+#endif
     *priv = res;
     return TRUE;
 }

--- a/triangle.c
+++ b/triangle.c
@@ -47,8 +47,8 @@ static void triangle(struct IDirect3D9 *d3d9, struct Xnine_private *priv)
     D3DPRESENT_PARAMETERS d3dpp;
     IDirect3DDevice9 *device = NULL;
     IDirect3DVertexBuffer9 *vertex_buf = NULL;
-    int width = 800;
-    int height = 600;
+    int width = WIDTH;
+    int height = HEIGHT;
     HWND hwnd;
     void* pVoid;
 

--- a/triangle.cpp
+++ b/triangle.cpp
@@ -47,8 +47,8 @@ static void triangle(struct IDirect3D9 *d3d9, struct Xnine_private *priv)
     D3DPRESENT_PARAMETERS d3dpp;
     IDirect3DDevice9 *device = NULL;
     IDirect3DVertexBuffer9 *vertex_buf = NULL;
-    int width = 800;
-    int height = 600;
+    int width = WIDTH;
+    int height = HEIGHT;
     HWND hwnd;
     void* pVoid;
 


### PR DESCRIPTION
- c2717b8c984dc1f74bf30312aa4c194b70f907c3 is a fix in the preprocessor code
- 4c0b8177df71d4c440f797a4f8dea72e2cac060f adds brackets around the `D3DADAPTER9_WITHDRI2` variable
- da97c5ffeb8e479edce5bcede21984eaf0a6b7d7 allows a `make clean && make` to run successfully. Currently it is failing because of a missing `dri3.o`, as it gets removed twice.
- others are self-explanatory I guess
