### PR TITLE
dri2: fix undefined reference to eglDestroyImageKHR

### DIFF
--- a/dri3.c
+++ b/dri3.c
@@ -139,6 +139,7 @@ struct DRI2priv {
     EGLContext context;
     PFNGLEGLIMAGETARGETTEXTURE2DOESPROC glEGLImageTargetTexture2DOES_func;
     PFNEGLCREATEIMAGEKHRPROC eglCreateImageKHR_func;
+    PFNEGLDESTROYIMAGEKHRPROC eglDestroyImageKHR_func;
 };
 
 /* TODO: We don't free memory properly. When exiting, eglTerminate doesn't work well(crash), and things are freed automatically. Rely on it */
@@ -149,6 +150,7 @@ DRI2FallbackInit(Display *dpy, struct DRI2priv **priv)
     PFNGLEGLIMAGETARGETTEXTURE2DOESPROC glEGLImageTargetTexture2DOES_func;
     PFNEGLCREATEIMAGEKHRPROC eglCreateImageKHR_func;
     PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT_func;
+    PFNEGLDESTROYIMAGEKHRPROC eglDestroyImageKHR_func;
     EGLDisplay display;
     EGLint major, minor;
     EGLConfig config;
@@ -183,7 +185,8 @@ DRI2FallbackInit(Display *dpy, struct DRI2priv **priv)
     extensions = eglQueryString(display, EGL_EXTENSIONS);
     if (!extensions || !strstr(extensions, "EGL_EXT_image_dma_buf_import") ||
         !strstr(extensions, "EGL_KHR_create_context") ||
-        !strstr(extensions, "EGL_KHR_surfaceless_context"))
+        !strstr(extensions, "EGL_KHR_surfaceless_context") ||
+        !strstr(extensions, "EGL_KHR_image_base"))
         goto clean_egl_display;
 
     if (!eglChooseConfig(display, config_attribs, &config, 1, &i))
@@ -200,6 +203,9 @@ DRI2FallbackInit(Display *dpy, struct DRI2priv **priv)
     eglCreateImageKHR_func = (PFNEGLCREATEIMAGEKHRPROC) eglGetProcAddress("eglCreateImageKHR");
     if (!eglCreateImageKHR_func || !glEGLImageTargetTexture2DOES_func)
         goto clean_egl_display;
+    eglDestroyImageKHR_func = (PFNEGLDESTROYIMAGEKHRPROC) eglGetProcAddress("eglDestroyImageKHR");
+    if (!eglDestroyImageKHR_func)
+        goto clean_egl_display;
 
     eglMakeCurrent(display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
 
@@ -211,6 +217,7 @@ DRI2FallbackInit(Display *dpy, struct DRI2priv **priv)
     (*priv)->context = context;
     (*priv)->glEGLImageTargetTexture2DOES_func = glEGLImageTargetTexture2DOES_func;
     (*priv)->eglCreateImageKHR_func = eglCreateImageKHR_func;
+    (*priv)->eglDestroyImageKHR_func = eglDestroyImageKHR_func;
     eglBindAPI(current_api);
     return TRUE;
 
@@ -988,7 +995,7 @@ DRI2FallbackPRESENTPixmap(PRESENTpriv *present_priv, struct DRI2priv *dri2_priv,
     if (status != GL_FRAMEBUFFER_COMPLETE)
         goto fail;
     glBindTexture(GL_TEXTURE_2D, 0);
-    eglDestroyImageKHR(dri2_priv->display, image);
+    dri2_priv->eglDestroyImageKHR_func(dri2_priv->display, image);
 
     /* We bind a newly created pixmap (to which we want to copy the content)
      * to an EGLImage, then to a texture, then to a fbo. */
@@ -1014,7 +1021,7 @@ DRI2FallbackPRESENTPixmap(PRESENTpriv *present_priv, struct DRI2priv *dri2_priv,
     if (status != GL_FRAMEBUFFER_COMPLETE)
         goto fail;
     glBindTexture(GL_TEXTURE_2D, 0);
-    eglDestroyImageKHR(dri2_priv->display, image);
+    dri2_priv->eglDestroyImageKHR_func(dri2_priv->display, image);
 
     eglMakeCurrent(dri2_priv->display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
 


### PR DESCRIPTION
I basically did the same changes which have been done for wine.
- check for `EGL_KHR_image_base`
- extend the `struct DRI2priv`
- Use `eglGetProcAddress("eglDestroyImageKHR")` to get the function

Fixes #2 
